### PR TITLE
bugfix(stats) : Bugfix accumulatedCost with upgrade probabilities

### DIFF
--- a/src/lib/Stats/Account.js
+++ b/src/lib/Stats/Account.js
@@ -186,7 +186,8 @@ class BattleLogsStatsAccount {
 
                 if (level > 1) {
                     for (let i = 2; i <= level; i++) {
-                        accumulatedCost += cheveuxCost[obj["rarity"]] / upgradeProbabilities[i];
+                        // For a given level, probabilities are stored in index i - 1
+                        accumulatedCost += cheveuxCost[obj["rarity"]] / upgradeProbabilities[i - 1];
                     }
                 }
 


### PR DESCRIPTION
Pour reproduire, il suffit d'avoir une arme / calv / item nv.15 => 

Account.js::processItems() renvoie NaN pour accumulatedCost puisqu'il n'y a pas d'entrée upgradeProbabilities[15].

Resolution : 
Quand un item est à un level X il faut utiliser la proba avec l'index X-1 
(exemple avec un item 15 => upgradeProbabilities[14] )