### PR TITLE
Fonctionnalité : Verrouiller le layout du BL

### DIFF
--- a/battlelogs.css
+++ b/battlelogs.css
@@ -100,6 +100,15 @@ body{
     height: 100%;
 }
 
+#Menu-Position.open.battlelogs-locked {
+    pointer-events: none;
+}
+
+#Menu-Position.open.battlelogs-locked #Menu-Lock {
+    pointer-events: initial;
+    background-color: #58585c;
+}
+
 .console {
     width: 100%;
     height: 100%;
@@ -1047,6 +1056,13 @@ button.svg_chat {
 }
 .svg_lock {
     background: url('data:image/svg+xml,<svg width="16" height="16" viewBox="0 0 0.72 0.72" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M.36.06a.15.15 0 0 1 .15.143V.3A.09.09 0 0 1 .6.39v.18a.09.09 0 0 1-.09.09h-.3A.09.09 0 0 1 .12.57V.39A.09.09 0 0 1 .21.3V.21A.15.15 0 0 1 .36.06Zm.15.3h-.3a.03.03 0 0 0-.03.03v.18A.03.03 0 0 0 .21.6h.3A.03.03 0 0 0 .54.57V.39A.03.03 0 0 0 .51.36ZM.365.12H.36a.09.09 0 0 0-.09.085V.3h.18V.21A.09.09 0 0 0 .365.12H.36h.005Z"/></svg>') no-repeat center;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+}
+
+.svg_lock_white {
+    background: url('data:image/svg+xml,<svg width="16" height="16" viewBox="0 0 0.72 0.72" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" fill="%23fff" d="M.36.06a.15.15 0 0 1 .15.143V.3A.09.09 0 0 1 .6.39v.18a.09.09 0 0 1-.09.09h-.3A.09.09 0 0 1 .12.57V.39A.09.09 0 0 1 .21.3V.21A.15.15 0 0 1 .36.06Zm.15.3h-.3a.03.03 0 0 0-.03.03v.18A.03.03 0 0 0 .21.6h.3A.03.03 0 0 0 .54.57V.39A.03.03 0 0 0 .51.36ZM.365.12H.36a.09.09 0 0 0-.09.085V.3h.18V.21A.09.09 0 0 0 .365.12H.36h.005Z"/></svg>') no-repeat center;
     display: inline-block;
     width: 24px;
     height: 24px;

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -7,7 +7,8 @@ class BattleLogsMenu {
         MenuExpanded: "Menu-Expanded",
         MenuWidth: "Menu-Width",
         ToggleButtonPosition: "ToggleButton-Position",
-        MenuPosition: "Menu-Position"
+        MenuPosition: "Menu-Position",
+        MenuLock: "Menu-Lock",
     };
 
     static BattleLogsActions;
@@ -51,6 +52,9 @@ class BattleLogsMenu {
         btnImg.src = BattleLogsComponentLoader.__baseUrl + "images/bl_icon.png";
         this.ToggleButton.appendChild(btnImg)
 
+        if(BattleLogs.Utils.LocalStorage.getValue(BattleLogs.Menu.Settings.MenuLock) === "true") {
+            this.__internal__battleLogsContainer.classList.add('battlelogs-locked')
+        }
 
         // Append menu
         document.body.appendChild(this.Menu);
@@ -203,6 +207,7 @@ class BattleLogsMenu {
         const headerButtons = document.getElementById(
             "battlelogs-console_header-buttons"
         );
+        this.__internal__addLockButton(this.Settings.MenuLock, headerButtons);
         this.__internal__addOpacityButton(this.Settings.MenuOpacity, headerButtons);
         this.__internal__addExpandButton(this.Settings.MenuExpanded, headerButtons);
 
@@ -568,6 +573,28 @@ class BattleLogsMenu {
             this.__internal__battleLogsConsole.style.opacity = opacity;
             BattleLogs.Utils.LocalStorage.setValue(buttonElem.id, opacity);
         });
+
+        containingDiv.appendChild(buttonElem);
+        this.__internal__battleLogsDockSideElement = buttonElem;
+    }
+
+    /**
+     * @desc Add lock button element
+     *
+     * @param {string} id: The button id
+     * @param {Element} containingDiv: The div element to append the button to
+     */
+    static __internal__addLockButton(id, containingDiv) {
+        let buttonElem = document.createElement("button");
+        buttonElem.id = id;
+        buttonElem.classList.add("svg_lock_white");
+        buttonElem.title = "Verrouiller la disposition";
+
+        buttonElem.onclick = () => {
+            let menu = document.getElementById(this.Settings.MenuPosition);
+            menu.classList.contains('battlelogs-locked') ? menu.classList.remove('battlelogs-locked') : menu.classList.add('battlelogs-locked');
+            BattleLogs.Utils.LocalStorage.setValue(buttonElem.id, menu.classList.contains('battlelogs-locked') ? "true": "false");
+        };
 
         containingDiv.appendChild(buttonElem);
         this.__internal__battleLogsDockSideElement = buttonElem;


### PR DESCRIPTION
Ajout d'une fonctionnalité pour verrouiller la disposition du BL pour pouvoir continuer de voir les infos (par exemple en opacité réduite) mais de pouvoir interagir avec l'UI du jeu sans déplacer le log dans tous les sens