### PR TITLE
Ajout fonctionnalité verrouillage positionnement du BL

### DIFF
--- a/battlelogs.css
+++ b/battlelogs.css
@@ -100,6 +100,15 @@ body{
     height: 100%;
 }
 
+#Menu-Position.open.battlelogs-locked {
+    pointer-events: none;
+}
+
+#Menu-Position.open.battlelogs-locked #Menu-Lock {
+    pointer-events: initial;
+    background-color: #58585c;
+}
+
 .console {
     width: 100%;
     height: 100%;
@@ -1047,6 +1056,13 @@ button.svg_chat {
 }
 .svg_lock {
     background: url('data:image/svg+xml,<svg width="16" height="16" viewBox="0 0 0.72 0.72" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M.36.06a.15.15 0 0 1 .15.143V.3A.09.09 0 0 1 .6.39v.18a.09.09 0 0 1-.09.09h-.3A.09.09 0 0 1 .12.57V.39A.09.09 0 0 1 .21.3V.21A.15.15 0 0 1 .36.06Zm.15.3h-.3a.03.03 0 0 0-.03.03v.18A.03.03 0 0 0 .21.6h.3A.03.03 0 0 0 .54.57V.39A.03.03 0 0 0 .51.36ZM.365.12H.36a.09.09 0 0 0-.09.085V.3h.18V.21A.09.09 0 0 0 .365.12H.36h.005Z"/></svg>') no-repeat center;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+}
+
+.svg_lock_white {
+    background: url('data:image/svg+xml,<svg width="16" height="16" viewBox="0 0 0.72 0.72" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" fill="%23fff" d="M.36.06a.15.15 0 0 1 .15.143V.3A.09.09 0 0 1 .6.39v.18a.09.09 0 0 1-.09.09h-.3A.09.09 0 0 1 .12.57V.39A.09.09 0 0 1 .21.3V.21A.15.15 0 0 1 .36.06Zm.15.3h-.3a.03.03 0 0 0-.03.03v.18A.03.03 0 0 0 .21.6h.3A.03.03 0 0 0 .54.57V.39A.03.03 0 0 0 .51.36ZM.365.12H.36a.09.09 0 0 0-.09.085V.3h.18V.21A.09.09 0 0 0 .365.12H.36h.005Z"/></svg>') no-repeat center;
     display: inline-block;
     width: 24px;
     height: 24px;

--- a/battlelogs.css
+++ b/battlelogs.css
@@ -104,8 +104,15 @@ body{
     pointer-events: none;
 }
 
-#Menu-Position.open.battlelogs-locked #Menu-Lock {
+#Menu-Position.open.battlelogs-locked .header-buttons button,
+#Menu-Position.open.battlelogs-locked .actions button,
+#Menu-Position.open.battlelogs-locked .bl-footer button,
+#Menu-Position.open.battlelogs-locked .unlocked
+{
     pointer-events: initial;
+}
+
+#Menu-Position.open.battlelogs-locked #Menu-Lock {
     background-color: #58585c;
 }
 
@@ -359,21 +366,30 @@ body{
 /* Sélectionne le span avec la classe "type" */
 
 .type {
-    position: relative; /* ajoute une position relative pour le span */
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    min-width: 40px;
 }
-.type:hover::before {
+
+.type:hover .type-label::before {
     content: url("data:image/svg+xml, %3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' color='%23959595'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16'%3E%3C/path%3E%3C/svg%3E");
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
+    position: relative;
+    left: calc(50% - 8px);
+    top: 8px;
+    width: 0;
     text-align: center;
     color: white;
     cursor: pointer;
 }
 
-.type:hover > span {
+.type > span {
+    margin: 0 auto;
+}
+
+.type:hover .type-label > span {
     visibility: hidden;
+    margin: 0 -8px;
 }
 
 /*********************/

--- a/src/lib/Glossary.js
+++ b/src/lib/Glossary.js
@@ -54,6 +54,7 @@ class BattleLogsGlossary {
         // Add settings container
         this.GlossaryPanel = document.createElement("div");
         this.GlossaryPanel.id = "battlelogs-glossary_panel";
+        this.GlossaryPanel.classList.add('unlocked');
         if (!(BattleLogs.Utils.LocalStorage.getValue(this.Settings.GlossaryEnable) === "true")) {
             this.GlossaryPanel.classList.add("hidden")
         }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -232,6 +232,7 @@ class BattleLogsMenu {
         // Add settings container to the UI
         this.BattleLogsSettings = document.createElement("div");
         this.BattleLogsSettings.id = "battlelogs-menu_settings";
+        this.BattleLogsSettings.classList.add('unlocked');
         this.BattleLogsWrapper.appendChild(this.BattleLogsSettings);
     }
 
@@ -597,7 +598,6 @@ class BattleLogsMenu {
         };
 
         containingDiv.appendChild(buttonElem);
-        this.__internal__battleLogsDockSideElement = buttonElem;
     }
 
     /**

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -7,7 +7,8 @@ class BattleLogsMenu {
         MenuExpanded: "Menu-Expanded",
         MenuWidth: "Menu-Width",
         ToggleButtonPosition: "ToggleButton-Position",
-        MenuPosition: "Menu-Position"
+        MenuPosition: "Menu-Position",
+        MenuLock: "Menu-Lock",
     };
 
     static BattleLogsActions;
@@ -51,6 +52,9 @@ class BattleLogsMenu {
         btnImg.src = BattleLogsComponentLoader.__baseUrl + "images/bl_icon.png";
         this.ToggleButton.appendChild(btnImg)
 
+        if(BattleLogs.Utils.LocalStorage.getValue(BattleLogs.Menu.Settings.MenuLock) === "true") {
+            this.__internal__battleLogsContainer.classList.add('battlelogs-locked')
+        }
 
         // Append menu
         document.body.appendChild(this.Menu);
@@ -203,6 +207,7 @@ class BattleLogsMenu {
         const headerButtons = document.getElementById(
             "battlelogs-console_header-buttons"
         );
+        this.__internal__addLockButton(this.Settings.MenuLock, headerButtons);
         this.__internal__addOpacityButton(this.Settings.MenuOpacity, headerButtons);
         this.__internal__addExpandButton(this.Settings.MenuExpanded, headerButtons);
 
@@ -568,6 +573,28 @@ class BattleLogsMenu {
             this.__internal__battleLogsConsole.style.opacity = opacity;
             BattleLogs.Utils.LocalStorage.setValue(buttonElem.id, opacity);
         });
+
+        containingDiv.appendChild(buttonElem);
+        this.__internal__battleLogsDockSideElement = buttonElem;
+    }
+
+    /**
+     * @desc Add lock button element
+     *
+     * @param {string} id: The button id
+     * @param {Element} containingDiv: The div element to append the button to
+     */
+    static __internal__addLockButton(id, containingDiv) {
+        let buttonElem = document.createElement("button");
+        buttonElem.id = id;
+        buttonElem.classList.add("svg_lock_white");
+        buttonElem.title = "Verrouiller la disposition";
+
+        buttonElem.onclick = () => {
+            let menu = document.getElementById(this.Settings.MenuPosition);
+            menu.classList.contains('battlelogs-locked') ? menu.classList.remove('battlelogs-locked') : menu.classList.add('battlelogs-locked');
+            BattleLogs.Utils.LocalStorage.setValue(buttonElem.id, menu.classList.contains('battlelogs-locked') ? "true": "false");
+        };
 
         containingDiv.appendChild(buttonElem);
         this.__internal__battleLogsDockSideElement = buttonElem;

--- a/src/lib/Message.js
+++ b/src/lib/Message.js
@@ -116,11 +116,17 @@ class BattleLogsMessage {
         // Create span element for type
         const spanTypeEl = document.createElement("span");
         const subSpan = document.createElement("span");
-        spanTypeEl.classList.add("type");
-        subSpan.innerHTML = type;
-        spanTypeEl.onclick = () => {
+        const label = document.createElement("span");
+
+        spanTypeEl.classList.add("type", "unlocked");
+        subSpan.classList.add("type-label");
+
+        label.innerHTML = type;
+        subSpan.onclick = () => {
             this.deleteMessage(pElem)
         }
+
+        subSpan.appendChild(label);
         spanTypeEl.appendChild(subSpan)
         pElem.appendChild(spanTypeEl);
 

--- a/src/lib/Stats.js
+++ b/src/lib/Stats.js
@@ -251,7 +251,7 @@ class BattleLogsStats {
         // Add settings container
         this.StatsPanel = document.createElement("div");
         this.StatsPanel.id = "battlelogs-stats_panel";
-        this.StatsPanel.classList.add("stats")
+        this.StatsPanel.classList.add("stats", "unlocked");
         if (!(BattleLogs.Utils.LocalStorage.getValue(this.Settings.StatsEnable) === "true")) {
             this.StatsPanel.classList.add("hidden")
         }


### PR DESCRIPTION
Ajout d'une fonctionnalité pour verrouiller la disposition du BL pour pouvoir continuer de voir les infos (par exemple en opacité réduite) mais de pouvoir interagir avec l'UI derrière du jeu sans déplacer le log dans tous les sens